### PR TITLE
Re-arrange initializers in MMAPFile to match declaration

### DIFF
--- a/src/util.cxx
+++ b/src/util.cxx
@@ -29,7 +29,7 @@ IOError::IOError(const char* text, int new_errno)
 }
 
 MMAPFile::MMAPFile()
-	: fd(-1), pos(0), length(0), data(0)
+	: fd(-1), data(0), length(0), pos(0)
 {
 }
 
@@ -37,7 +37,7 @@ MMAPFile::MMAPFile()
 MMAPFile::MMAPFile(const MMAPFile& ref)
 	// just copy the data necessary for read/seek
 	// but not the one needed to close/unmap
-	: fd(-1), pos(ref.pos), end(ref.end), length(0), data(ref.data)
+	: fd(-1), data(ref.data), length(0), pos(ref.pos), end(ref.end)
 {
 }
 


### PR DESCRIPTION
The g++ 10 compiler issues a -Wreorder warning about the order of
initializers not matching the order of fields in the structure, and that
the initializers are re-ordered.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>